### PR TITLE
fix: handle editor command args

### DIFF
--- a/chaos-sail.py
+++ b/chaos-sail.py
@@ -8,6 +8,7 @@ import datetime as dt
 import os
 import random
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -59,9 +60,16 @@ def append_journal(root: Path, line: str) -> None:
 
 
 def pick_editor() -> List[str]:
+    """Return the user's preferred editor as an argv list.
+
+    `EDITOR`/`VISUAL` may contain additional arguments (e.g. ``code -w``),
+    so we need to split the string similarly to how a shell would.  The
+    previous implementation returned the entire string as a single element,
+    causing lookups to fail when an editor command included spaces.
+    """
     editor = os.environ.get("EDITOR") or os.environ.get("VISUAL")
     if editor:
-        return [editor]
+        return shlex.split(editor)
     if os.name == "nt":
         return ["notepad"]
     return ["vim"]


### PR DESCRIPTION
## Summary
- split EDITOR/VISUAL env vars using shlex so editors with arguments work

## Testing
- `python -m py_compile chaos-sail.py`
- `python chaos-sail.py --help`
- `python - <<'PY'\nimport os, runpy\nm = runpy.run_path('chaos-sail.py')\nfun = m['pick_editor']\nos.environ['EDITOR'] = 'code -w'\nprint(fun())\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68aeafb8eeb48324a0fd2501a4fd1eb9